### PR TITLE
Remove AS37353 (MacroLan)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -762,11 +762,6 @@ AS6453:
         - 80.249.209.167
         - 2001:7f8:1::a500:6453:1
 
-AS37353:
-    description: MacroLan
-    import: AS-MACROLAN
-    export: "AS8283:AS-COLOCLUE"
-
 AS1257:
     description: Tele2 SWIPNet
     import: AS-TELE2


### PR DESCRIPTION
Since they are leaving the NL-IX and we don't have any other IXes in common, I've removed them.