### PR TITLE
Disable the IPv4 prefix limit on Level 3

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -597,7 +597,7 @@ AS3356:
     description: Level3
     import: ANY
     export: "AS8283:AS-COLOCLUE"
-    ipv4_limit: 700000
+    ipv4_limit: 0
     ipv6_limit: 50000
     ignore_peeringdb: True
     private_peerings:

--- a/tests/test_peering_relations.py
+++ b/tests/test_peering_relations.py
@@ -87,8 +87,8 @@ for asn in peerings:
                 print "ERROR: %s must be a positive integer" % limit
                 print peerings[asn]
                 sys.exit(2)
-            if not l > 0:
-                print "ERROR: %s must be larger then 1" % limit
+            if not l >= 0:
+                print "ERROR: %s must be larger then or equal to 0" % limit
                 print peerings[asn]
                 sys.exit(2)
 


### PR DESCRIPTION
Since we accept more routes then there are in the DFZ from them, we could disable this limit without issue.
This prevents issues in the future, when the DFZ grows beyond 700.000 routes.