### PR TITLE
Only activate AS12654 on first NL-IX port

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -192,6 +192,8 @@ AS12654:
     description: RIPE NCC RIS Project
     import: AS12654:RS-RIS
     export: ANY
+    only_on:
+        - dcg-1.router.nl.coloclue.net
 
 AS2906:
     description: Netflix


### PR DESCRIPTION
Using the new only_on feature, you can now specify on which router(s) of the IX the session should be set up.
This feature was requested by AS12654 (RIPE NCC RIS project) for who it doesn't make sense to peer on both NL-IX ports.