### PR TITLE
Update the ASN for the WikiMedia foundation

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -459,7 +459,7 @@ AS50673:
     import: AS-SERVERIUS
     export: "AS8283:AS-COLOCLUE"
 
-AS43821:
+AS14907:
     description: Wikimedia Foundation
     import: AS-WIKIMEDIA
     export: "AS8283:AS-COLOCLUE"


### PR DESCRIPTION
The WikiMedia foundation is merging their two ASNs into one, causing us to update the ASN to the new one.

*** NOTE ***
Note: This MUST NOT be merged before October 11th 00:00 UTC, because before that time the WikiMedia Foundation haven't reconfigured their end for this configuration. If we merge before that time, our sessions with the WikiMedia Foundation will go down or at lease become unstable.
So please, DO NOT merge before October 11th 00:00 UTC
*** ENDNOTE ***