### PR TITLE
Only peer with NFOrce via the NL-IX

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -565,6 +565,11 @@ AS43350:
     description: NFOrce Entertainment B.V.
     import: AS-NFORCE
     export: "AS8283:AS-COLOCLUE"
+    only_with:
+      - 193.239.116.142
+      - 193.239.116.214
+      - 2001:7f8:13::a504:3350:1
+      - 2001:7f8:13::a504:3350:2
 
 AS48519:
     description: Knipp Medien und Kommunikation GmbH


### PR DESCRIPTION
NFOrce Entertainment B.V. is reducing the amount of direct peering settings. Thus we don't peer on the AMS-IX anymore, only via the route servers.
We don't peer with the route servers on the NL-IX, thus those settings remain active.