### PR TITLE
Remove AS260 (Xconnect24)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -1,9 +1,4 @@
 ---
-AS260:
-    description: Xconnect24
-    import: AS-XCONNECT24
-    export: "AS8283:AS-COLOCLUE"
-
 AS1200:
     description: AMS-IX Office
     import: AS1200


### PR DESCRIPTION
AS260 (Xconnect24) has been bought by GTT, so they are placed behind AS3257. Thus the direct session to AS260 can be removed.