### PR TITLE
Remove AS8928 (Interoute)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -627,11 +627,6 @@ AS1103:
     import: AS-SURFNET
     export: "AS8283:AS-COLOCLUE"
 
-AS8928:
-    description: Interoute
-    import: AS-INTEROUTE
-    export: "AS8283:AS-COLOCLUE"
-
 AS15542:
     description: ZeelandNet
     import: AS-ZEELANDNET


### PR DESCRIPTION
Remove AS8928 (Interoute) because they are moved behind AS3257 (GTT)