### PR TITLE
Remove Tilaa

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -125,11 +125,6 @@ AS58291:
     import: AS-COLOCENTER
     export: "AS8283:AS-COLOCLUE"
 
-AS196752:
-    description: Tilaa
-    import: AS-TILAA
-    export: "AS8283:AS-COLOCLUE"
-
 AS9150:
     description: Interconnect Services
     import: AS-INTERCONNECT


### PR DESCRIPTION
We also see Tilaa via the AMS-IX Route Server, dedicated sessions aren't needed.