### PR TITLE
Temporalily disable Joey Network

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -755,10 +755,10 @@ AS13414:
     import: AS-TWITTER
     export: AS8283:AS-COLOCLUE
 
-AS49697:
-    description: Joey Network
-    import: AS-JOEYNETWORK
-    export: AS8283:AS-COLOCLUE
+#AS49697:
+#    description: Joey Network
+#    import: AS-JOEYNETWORK
+#    export: AS8283:AS-COLOCLUE
     
 AS205591:
     description: Stefan6 Network


### PR DESCRIPTION
Joey has removed his SPEED-IX definition from PeeringDB, resulting in no sessions in common anymore. I've disabled his peering definition now, so the checks complete succesfully again.