### PR TITLE
Peer with Github AS36459

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -864,3 +864,8 @@ AS197301:
     description: Parknet F.M.B.A.
     import: AS-PARKNET
     export: AS8283:AS-COLOCLUE
+
+AS36459:
+    description: GitHub Inc.
+    import: AS-GITHUB
+    export: AS8283:AS-COLOCLUE


### PR DESCRIPTION
We're available at AMS-IX and soon at AsteroidIX AMS.

GitHub, Inc. is happy to peer with Coloclue.

ASN - 36459
IRR (ARIN, RIPE): AS-GITHUB

http://as36459.peeringdb.com/
NOC: noc@github.com
Contact: peering@github.com

- AMS-IX, Amsterdam -
Router 1:
80.249.213.114
2001:7F8:1::A503:6459:1
