### PR TITLE
Create a static config for Cloudflare

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -482,6 +482,14 @@ AS13335:
     description: Cloudflare
     import: AS-CLOUDFLARE
     export: "AS8283:AS-COLOCLUE"
+    ignore_peeringdb: True
+    ipv4_limit: 500
+    ipv6_limit: 100
+    only_with:
+        - 80.249.211.140
+        - 2001:7f8:1::a501:3335:1
+        - 193.239.117.114
+        - 2001:7f8:13::a501:3335:1
 
 AS32934:
     description: Facebook


### PR DESCRIPTION
Cloudflare doesn't want to peer with us using their new second router on the NL-IX, so we have to switch to a static config for them, to be able to filter out the router a session won't be formed on anyway.