### PR TITLE
Removed decommissioned Level3

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -574,17 +574,6 @@ AS31027:
     import: AS-NIANET
     export: "AS8283:AS-COLOCLUE"
 
-AS3356:
-    description: Level3
-    import: ANY
-    export: "AS8283:AS-COLOCLUE"
-    ipv4_limit: 0
-    ipv6_limit: 50000
-    ignore_peeringdb: True
-    private_peerings:
-        - 4.68.73.169
-        - 2001:1900:5:3::191
-
 AS38880:
     description: Micron21
     import: AS-M21

--- a/peers.yaml
+++ b/peers.yaml
@@ -887,3 +887,4 @@ AS64050:
     description: BGP Consultancy Pte Ltd
     import: AS64050
     export: AS8283:AS-COLOCLUE
+...


### PR DESCRIPTION
Level 3 removed the router that was peering with us, thus they disabled the peering. Removed this now unneeded configuration