### PR TITLE
Remove level3 peering

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -574,17 +574,6 @@ AS31027:
     import: AS-NIANET
     export: "AS8283:AS-COLOCLUE"
 
-AS3356:
-    description: Level3
-    import: ANY
-    export: "AS8283:AS-COLOCLUE"
-    ipv4_limit: 0
-    ipv6_limit: 50000
-    ignore_peeringdb: True
-    private_peerings:
-        - 4.68.73.169
-        - 2001:1900:5:3::191
-
 AS38880:
     description: Micron21
     import: AS-M21


### PR DESCRIPTION
Level3 has decommissioned the private peering with us, thus removing the configuration from our routers.