### PR TITLE
Disable peering to AS25596 via SPEED-IX

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -473,6 +473,9 @@ AS25596:
     description: Cambrium
     import: AS-CAMBRIUM
     export: "AS8283:AS-COLOCLUE"
+    not_on:
+      - 185.1.95.124
+      - 2001:7f8:b7::a502:5596:1
 
 AS8218:
     description: Zayo France


### PR DESCRIPTION
Cambrium (AS25596) doesn't peer on SPEED-IX, so I added an option to peers.yml to exclude specific routers from setting up BGP sessions. The update for Kees itself which supports this option will follow shortly.