### PR TITLE
Change to IXP instead of peer IPs for not_on

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -474,8 +474,7 @@ AS25596:
     import: AS-CAMBRIUM
     export: "AS8283:AS-COLOCLUE"
     not_on:
-      - 185.1.95.124
-      - 2001:7f8:b7::a502:5596:1
+      - speedix
 
 AS8218:
     description: Zayo France


### PR DESCRIPTION
It is easier in Kees to proces specific IXPs for the not_on functionality, so I switched the config for Cambrium (AS25596) to the new way of working.