### PR TITLE
Disable peering with Google on Asteroid and SpeedIX

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -644,6 +644,9 @@ AS15169:
     description: Google
     import: AS-GOOGLE
     export: "AS8283:AS-COLOCLUE"
+    not_on:
+      - asteroid
+      - speedix
 
 AS59605:
     description: Zain Group


### PR DESCRIPTION
Google is giving us a hard time for setting up sessions over Asteroid and SpeedIX, so let's just remove the sessions on them. They aren't established anyway.