### PR TITLE
Remove unneeded prefix limits for AS6453

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -672,6 +672,7 @@ AS6453:
     description: Tata
     import: AS-GLOBEINTERNET
     export: "AS8283:AS-COLOCLUE"
+    ignore_peeringdb: True
     only_with:
         - 80.249.209.167
         - 2001:7f8:1::a500:6453:1

--- a/peers.yaml
+++ b/peers.yaml
@@ -672,9 +672,6 @@ AS6453:
     description: Tata
     import: AS-GLOBEINTERNET
     export: "AS8283:AS-COLOCLUE"
-    ipv4_limit: 242000
-    ipv6_limit: 18700
-    ignore_peeringdb: True
     only_with:
         - 80.249.209.167
         - 2001:7f8:1::a500:6453:1


### PR DESCRIPTION
The static prefix limits for AS6453 aren't needed anymore, the correct values are on PeeringDB nowdays, so we can extract them from there.