### PR TITLE
Remove peering with AS1140 (SIDN)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -125,11 +125,6 @@ AS9150:
     import: AS-INTERCONNECT
     export: "AS8283:AS-COLOCLUE"
 
-AS1140:
-    description: SIDN
-    import: AS-SIDN
-    export: "AS8283:AS-COLOCLUE"
-
 AS20562:
     description: OpenPeering
     import: AS-OPENPEERING


### PR DESCRIPTION
They don't peer anymore on AS1140, only some private peering, which Coloclue isn't. So this session is unneeded