### PR TITLE
Remove NL-ix sessions for AS10310 (Yahoo)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -624,6 +624,8 @@ AS10310:
     description: Yahoo
     import: AS-YAHOO
     export: "AS8283:AS-COLOCLUE"
+    not_on:
+      - nlix
 
 AS48635:
     description: PCextreme


### PR DESCRIPTION
AS10310 (Yahoo) has decided to not directly peer on the NL-ix anymore. To not hammer their routers with needless BGP connection attempts I removed the sessions over the NL-ix towards them