### PR TITLE
Add AS37100 (Seacom)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -935,3 +935,7 @@ AS49627:
     import: AS49627
     export: AS8283:AS-COLOCLUE
 
+AS37100:
+    description: Seacom
+    import: AFRINIC::AS-SET-SEACOM
+    export: AS8282:AS-COLOCLUE

--- a/peers.yaml
+++ b/peers.yaml
@@ -938,4 +938,4 @@ AS49627:
 AS37100:
     description: Seacom
     import: AFRINIC::AS-SET-SEACOM
-    export: AS8282:AS-COLOCLUE
+    export: AS8283:AS-COLOCLUE


### PR DESCRIPTION
Seacom is leaving the route servers, so we are setting up direct peering sessions with them, to remain the option to send traffic directly to them.