### PR TITLE
Remove AS15542 (ZeelandNet)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -604,11 +604,6 @@ AS1103:
     import: AS-SURFNET
     export: "AS8283:AS-COLOCLUE"
 
-AS15542:
-    description: ZeelandNet
-    import: AS-ZEELANDNET
-    export: "AS8283:AS-COLOCLUE"
-
 AS24875:
     description: NovoServe
     import: AS-NOVOSERVE


### PR DESCRIPTION
AS15542 (ZeelandNet) now only lives behind AS15435 (Caiway), so direct peering is useless to have.