### PR TITLE
Update AS-SET for AS37100 (Seacom)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -932,5 +932,5 @@ AS49627:
 
 AS37100:
     description: Seacom
-    import: AFRINIC::AS-SET-SEACOM
+    import: AS-SET-SEACOM
     export: AS8283:AS-COLOCLUE


### PR DESCRIPTION
Kees didn't accept the old way of specifying the AS-SET for AS37100 (Seacom), so updated it to one Kees does accept.