### PR TITLE
Remove the fixed prefix limits for CloudFlare (AS13335)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -480,7 +480,6 @@ AS13335:
     description: Cloudflare
     import: AS-CLOUDFLARE
     export: "AS8283:AS-COLOCLUE"
-    ignore_peeringdb: True
     only_with:
         - 80.249.211.140
         - 2001:7f8:1::a501:3335:1

--- a/peers.yaml
+++ b/peers.yaml
@@ -481,8 +481,6 @@ AS13335:
     import: AS-CLOUDFLARE
     export: "AS8283:AS-COLOCLUE"
     ignore_peeringdb: True
-    ipv4_limit: 2000
-    ipv6_limit: 500
     only_with:
         - 80.249.211.140
         - 2001:7f8:1::a501:3335:1


### PR DESCRIPTION
We don't need to manually specify the prefix limits for CloudFlare, Kees can extract them automatically from PeeringDB. The ignore_peeringdb flag doesn't have influence on that.