### PR TITLE
Amsio is now part of Sentia, renamed the session

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -804,8 +804,8 @@ AS201701:
     export: AS8283:AS-COLOCLUE
     
 AS8315:
-    description: Amsio B.V.
-    import: AS8315:AS-AMSIO
+    description: Sentia Netherlands BV
+    import: AS8315:AS-SENTIA
     export: AS8283:AS-COLOCLUE
 
 AS24961:


### PR DESCRIPTION
Sentia is now the owner of Amsio. I've renamed the session to reflect this merger. Also the AS-SET has been renamed, so this is something that needs to be done, to keep the IRR filters correct in the future.