### PR TITLE
Exclude Speed-IX IPv6 with AS49627 (Speakup)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -921,6 +921,8 @@ AS49627:
     description: Speakup
     import: AS49627
     export: AS8283:AS-COLOCLUE
+    not_with:
+      - 2001:7f8:b7::a504:9627:1
 
 AS37100:
     description: Seacom


### PR DESCRIPTION
AS49627 (Speakup) doesn't have IPv6 connectivity on their Speed-IX facing router, so this session will never start.