### PR TITLE
Remove the session with AS59776 (Liberty Global CDN)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -500,14 +500,6 @@ AS6830:
     description: Liberty Global
     import: AS-AORTA AS-AORTA6
     export: "AS8283:AS-COLOCLUE"
-    
-
-AS59776:
-    description: Liberty Global CDN
-    import: AS59776
-    export: "AS8283:AS-COLOCLUE"
-    ipv4_limit: 15000
-    ipv6_limit: 1300
 
 AS6461:
     description: Zayo / Abovenet


### PR DESCRIPTION
Liberty Global found out that we already have a session with AS6830, so the session with AS59776 isn't needed. Thus, removing the session.