### PR TITLE
Remove AS60927

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -850,11 +850,6 @@ AS44222:
     import: AS-CLOUDITY
     export: AS8283:AS-COLOCLUE
 
-AS60927:
-    description: Marlinc
-    import: AS60927:AS-MARLINC
-    export: AS8283:AS-COLOCLUE
-
 AS51430:
     description: AltusHost B.V.
     import: AS51430


### PR DESCRIPTION
We don't have any IX-es in common anymore with marlinc (AS60927), thus removed the peer from the peerlist, because there is no point in having this peer in the list anymore