### PR TITLE
remove peering with AS201701 (Freifunk Rheinland e.V)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -785,11 +785,6 @@ AS19679:
     import: AS-DROPBOX
     export: AS8283:AS-COLOCLUE
 
-AS201701:
-    description: Freifunk Rheinland e.V.
-    import: AS-FFRL
-    export: AS8283:AS-COLOCLUE
-    
 AS8315:
     description: Sentia Netherlands BV
     import: AS8315:AS-SENTIA


### PR DESCRIPTION
We are temporary disconnected from NL-ix and we don't have an alternative peering point with you