### PR TITLE
Remove AS31334

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -257,11 +257,6 @@ AS2852:
     import: AS-CESNET
     export: "AS8283:AS-COLOCLUE"
 
-AS31334:
-    description: Kabel Deutschland
-    import: AS-KDG
-    export: "AS8283:AS-COLOCLUE"
-
 AS30132:
     description: Internet Systems Consortium, F-Root Operator
     import: AS30132:AS-SET


### PR DESCRIPTION
Kabel Deutschland (AS31334) has migrated to be fully behind Vodafone (AS3209). They are leaving the IXes with AS31334, thus removing the sessions