### PR TITLE
Move Freedom Internet to the correct AS-SET

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -944,5 +944,5 @@ AS47172:
     
 AS206238:
     description: Freedom Internet
-    import: AS206238
+    import: AS-FREEDOMNET
     export: AS8283:AS-COLOCLUE


### PR DESCRIPTION
An ASN was configured for Freedom Internet, while they have an AS-SET. So I moved to configuration over to the AS-SET