### PR TITLE
Update import filter for AS47065

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -21,7 +21,6 @@ AS3265:
 
 AS12713:
     description: OTEGLOBE
-    import: AS-OTEGLOBE
     export: "AS8283:AS-COLOCLUE"
 
 AS13285:
@@ -375,7 +374,7 @@ AS15562:
 
 AS47065:
     description: BGPMUX / PEERING TestBed
-    import: AS-PEERING-TESTBED
+    import: RS-PEERING-TESTBED
     export: ANY
     type: downstream
 

--- a/peers.yaml
+++ b/peers.yaml
@@ -21,6 +21,7 @@ AS3265:
 
 AS12713:
     description: OTEGLOBE
+    import: AS-OTEGLOBE
     export: "AS8283:AS-COLOCLUE"
 
 AS13285:


### PR DESCRIPTION
AS47065 (Peering TestBed) has changed the AS-SET they use for their IP space since we started peering. Updated it to the correct one.