### PR TITLE
Remove AS28876

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -322,11 +322,6 @@ AS49685:
     import: AS-ITIS
     export: "AS8283:AS-COLOCLUE"
 
-AS28876:
-    description: suec // dacor GmbH
-    import: AS-SUEC-DACOR
-    export: "AS8283:AS-COLOCLUE"
-
 AS8359:
     description: MTS
     import: AS-MTU


### PR DESCRIPTION
AS28876 has left the AMS-IX and now we don't have any IXes left in common. They are only active in Germany anymore, and we aren't, so I don't expect that we have an IX in common soon.