### PR TITLE
Remove AS14413 (LinkedIn)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -389,11 +389,6 @@ AS8075:
     import: AS-MICROSOFT
     export: "AS8283:AS-COLOCLUE"
 
-AS14413:
-    description: Linkedin
-    import: AS-LINKEDIN
-    export: "AS8283:AS-COLOCLUE"
-
 AS1764:
     description: Nextlayer.at
     import: AS-NEXTLAYER AS-NEXTLAYER-V6


### PR DESCRIPTION
LinkedIn has left the NL-ix and now we don't have any IXes in common anymore, so removing them from the peering list only makes sense now.