### PR TITLE
Remove AS23393

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -665,11 +665,6 @@ AS56647:
     import: AS56647
     export: "AS8283:AS-COLOCLUE"
 
-AS23393:
-    description: ISPrime
-    import: AS-ISPRIME
-    export: "AS8283:AS-COLOCLUE"
-
 AS6762:
     description: Telecom Italia Sparkle
     import: AS-SEABONE


### PR DESCRIPTION
AS23393 (ISPrime / BelugaCDN) has announced to us that they will shutdown the peering session, I have thus removed the definition of this peer from the list above.