### PR TITLE
Remove AS37271

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -650,11 +650,6 @@ AS54113:
 #    ipv4_limit: 80000
 #    ipv6_limit: 4000
 
-AS37271:
-    description: Workonline
-    import: AS-WOLCOMM
-    export: "AS8283:AS-COLOCLUE"
-
 AS49206:
     description: PeakFactory
     import: AS-PEAKFACTORY


### PR DESCRIPTION
AS37271 (Workonline) has disconnected from the NL-ix, and their peering policy states that they need a connection over 2 IXes. So, only via the AMS-IX isn't enough for them, so those sessions needs to be removed as wel. Doing that in this commit.