### PR TITLE
Don't connect internationally with AS54113

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -642,6 +642,11 @@ AS54113:
     description: Fastly inc.
     import: AS-FASTLY
     export: "AS8283:AS-COLOCLUE"
+    not_with:
+      - 193.239.118.130
+      - 193.239.118.162
+      - 2001:7f8:13::a505:4113:3
+      - 2001:7f8:13::a505:4113:2
 
 #AS3910:
 #    description: Centurylink


### PR DESCRIPTION
Removed 4 specific peer addresses for AS54113 (Fastly inc.) because they are in different countries than our routers, and by Fastly's policy they don't go internationally over an IXP. Thus removing these 4 sessions from the list.