### PR TITLE
Remove AS36459

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -791,11 +791,6 @@ AS197301:
     import: AS-PARKNET
     export: AS8283:AS-COLOCLUE
 
-AS36459:
-    description: GitHub Inc.
-    import: AS-GITHUB
-    export: AS8283:AS-COLOCLUE
-
 AS44222:
     description: CLOUDITY Network
     import: AS-CLOUDITY


### PR DESCRIPTION
Removing AS36459, because we don't have a IXP incommon with them anymore, resulting in failed tests when changing this file.