### PR TITLE
Remove AS20953

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -69,12 +69,6 @@ AS25091:
     import: AS-IP-MAX
     export: "AS8283:AS-COLOCLUE"
 
-AS20953:
-    description: info.nl
-    import: AS-INFO
-    export: "AS8283:AS-COLOCLUE"
-    gtsm: yes
-
 AS61349:
     description: MaxiTEL
     import: AS-MAXITEL


### PR DESCRIPTION
AS20953 (info.nl) has left public peering on all IXPs, so I'm removing the peering sessions with them.