### PR TITLE
Add the Frys-IX route servers

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -919,3 +919,8 @@ AS213035:
     description: Serverion B.V.
     import: AS-SERVERION
     export: AS8283:AS-COLOCLUE
+
+AS56393:
+    description: Frys-IX Route servers
+    import: AS56393
+    export: AS8283:AS-COLOCLUE

--- a/tests/test_peering_relations.py
+++ b/tests/test_peering_relations.py
@@ -49,6 +49,8 @@ connected_ixps = {
              ipaddr.IPNetwork('2001:7f8:b6:0:0:0:0:0/64')],
     "speedix": [ipaddr.IPNetwork('185.1.95.0/24'),
                 ipaddr.IPNetwork('2001:7f8:b7:0:0:0:0:0/64')],
+    "frysix": [ipaddr.IPNetwork('185.1.203.0/24'),
+                ipaddr.IPNetwork('2001:7f8:10f::205b::/64')],
     "private-eun": [ipaddr.IPNetwork('62.115.144.32/31'),
                     ipaddr.IPNetwork('2001:2000:3080:0EBC::/126')],
     "multihop-eun": [ipaddr.IPNetwork('4.68.4.43/32'),

--- a/tests/test_peering_relations.py
+++ b/tests/test_peering_relations.py
@@ -50,7 +50,7 @@ connected_ixps = {
     "speedix": [ipaddr.IPNetwork('185.1.95.0/24'),
                 ipaddr.IPNetwork('2001:7f8:b7:0:0:0:0:0/64')],
     "frysix": [ipaddr.IPNetwork('185.1.203.0/24'),
-                ipaddr.IPNetwork('2001:7f8:10f::205b::/64')],
+                ipaddr.IPNetwork('2001:7f8:10f::205b:0/64')],
     "private-eun": [ipaddr.IPNetwork('62.115.144.32/31'),
                     ipaddr.IPNetwork('2001:2000:3080:0EBC::/126')],
     "multihop-eun": [ipaddr.IPNetwork('4.68.4.43/32'),


### PR DESCRIPTION
We have another IXP on which we connect, namely the Frys-IX. Now we are adding the Frys-IX Route servers, to check if we can fully connect to it.