### PR TITLE
Peer with 49627 via Speed-IX over IPv6

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -843,8 +843,6 @@ AS49627:
     description: Speakup
     import: AS49627
     export: AS8283:AS-COLOCLUE
-    not_with:
-      - 2001:7f8:b7::a504:9627:1
 
 AS37100:
     description: Seacom


### PR DESCRIPTION
Speakup has added a working IPv6 config on their Speed-IX facing router, so now we can have peering via IPv6 as well.