### PR TITLE
Remove restrictions from the Cloudflare sessions

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -455,12 +455,7 @@ AS13335:
     description: Cloudflare
     import: AS-CLOUDFLARE
     export: "AS8283:AS-COLOCLUE"
-    only_with:
-        - 80.249.211.140
-        - 2001:7f8:1::a501:3335:1
-        - 193.239.117.114
-        - 2001:7f8:13::a501:3335:1
-
+    
 AS32934:
     description: Facebook
     import: AS-FACEBOOK


### PR DESCRIPTION
Cloudflare has indicated that they also want to peer on the Speed-IX, so the restrictions to only set up sessions over the AMS-IX and NL-ix aren't needed anymore. They are removed now.