### PR TITLE
Increase IPv4 limit for AS1299

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -499,7 +499,7 @@ AS1299:
     description: TeliaSonera International Carrier
     import: AS-TELIANET AS-TELIANET-V6
     export: "AS8283:AS-COLOCLUE"
-    ipv4_limit: 500000
+    ipv4_limit: 550000
     ipv6_limit: 90000
     ignore_peeringdb: True
     private_peerings:


### PR DESCRIPTION
We currently get 486k prefixes from Telia (AS1299) and the limit was 500k, so that is getting close. Telia recommends setting the limit to 550k on their PeeringDB page, so I increased the prefix limit to that amount