### PR TITLE
Test the peers.yaml again

### DIFF
--- a/.github/workflows/test_peers.yaml.yml
+++ b/.github/workflows/test_peers.yaml.yml
@@ -3,8 +3,6 @@ name: Test peers.yaml
 
 on:
   push:
-  pull_request:
-    types: [opened, edited, reopened]
 
 jobs:
   test-peers-yaml:

--- a/.github/workflows/test_peers.yaml.yml
+++ b/.github/workflows/test_peers.yaml.yml
@@ -1,0 +1,25 @@
+---
+name: Test peers.yaml
+
+on:
+  push:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  test-peers-yaml:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install ipaddr requests pyyaml
+    - name: Test peers.yaml
+      run: python ./tests/test_peering_relations.py


### PR DESCRIPTION
Peers.yaml isn't tested anymore via Travis for some reason. To get that test working again, I'm moving the test over to the Github Actions feature, which they launched since we started using Travis. This ensures the quality of the peers.yaml and prevents a Kees run from failing.