### PR TITLE
Remove AS12041

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -278,11 +278,6 @@ AS43190:
     import: AS-GLIX
     export: "AS8283:AS-COLOCLUE"
 
-AS12041:
-    description: Afilias
-    import: AS12041:AS-AFILIAS
-    export: "AS8283:AS-COLOCLUE"
-
 AS30781:
     description: Jaguar Network
     import: AS-JAGUAR AS-JAGUAR-V6


### PR DESCRIPTION
Afilias (AS12041) is disconnecting all their public peerings and are only visible via the route servers from now on. So there is no need to have these sessions specifically configured anymore, because they will be broken anyway. Since we do peer with all the route servers, there will be no impact on the traffic flows.