### PR TITLE
Remove AS35332 (DataWeb)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -218,11 +218,6 @@ AS34968:
     import: AS-IUNXI
     export: "AS8283:AS-COLOCLUE"
 
-AS35332:
-    description: Dataweb
-    import: AS-DATAWEB
-    export: "AS8283:AS-COLOCLUE"
-
 AS6724:
     description: Strato
     import: AS-STRATORZ


### PR DESCRIPTION
DataWeb no longer peers on the NL-ix and this is the only IX we had in common with them, thus removing them from peers.yaml, to clean up our BGP session lists.