### PR TITLE
Update Google peering

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -578,6 +578,9 @@ AS15169:
     not_on:
       - asteroid
       - speedix
+      - decix
+      - franceix
+      - swissix
 
 AS59605:
     description: Zain Group


### PR DESCRIPTION
We can only peer with Google over the NL-ix and AMS-IX, so filtering out all other IXes. Since we have a port on the DE-CIX, France-IX and SwissIX nowadays, these sessions need to be removed from the attempts to peer with Google.