### PR TITLE
Don't peer with AS12859 on DE-CIX

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -60,6 +60,8 @@ AS12859:
     description: BIT
     import: AS-BIT AS-BIT6
     export: "AS8283:AS-COLOCLUE"
+    not_on:
+      - decix
 
 AS13101:
     description: TNG


### PR DESCRIPTION
AS12859 has given the signal that they don't want to peer on the DE-CIX. It doesn't make a lot of sense to peer on it anyway, since both AS8283 and AS12859 are Dutch ISPs