### PR TITLE
Don't peer with Google over the Frys-IX

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -583,6 +583,7 @@ AS15169:
       - decix
       - franceix
       - swissix
+      - frysix
 
 AS59605:
     description: Zain Group


### PR DESCRIPTION
Google doesn't want to peer with us over the Frys-IX, so let's remove those sessions.