### PR TITLE
Get AS48886 info from PeeringDB

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -790,10 +790,6 @@ AS48886:
     description: CS Net
     import: AS48886
     export: AS8283:AS-COLOCLUE
-    ignore_peeringdb: True
-    only_with:
-      - 193.239.116.209
-      - 193.239.117.19
 
 AS57782:
     description: Cynthia Maja Revstrom


### PR DESCRIPTION
AS48886 (CS Net) has published a PeeringDB record. Thus we can now extract the needed information from it, we don't have to specify everything ourselves anymore.