### PR TITLE
Remove AS6724

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -220,11 +220,6 @@ AS34968:
     import: AS-IUNXI
     export: "AS8283:AS-COLOCLUE"
 
-AS6724:
-    description: Strato
-    import: AS-STRATORZ
-    export: "AS8283:AS-COLOCLUE"
-
 AS197731:
     description: Tuxis Internet Engineering
     import: AS-TUXIS


### PR DESCRIPTION
AS6724 (Strato) is now single homed behind AS8560, so no need to have a direct connection with them anymore. They have removed all information from PeeringDB anyway.