### PR TITLE
Update peers.yaml

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -58,7 +58,7 @@ AS21478:
 
 AS12859:
     description: BIT
-    import: AS-BIT AS-BIT6
+    import: AS-BIT
     export: "AS8283:AS-COLOCLUE"
     not_on:
       - decix


### PR DESCRIPTION
AS-BIT6 is deprecated, we use AS-BIT for both IPv4 and IPv6 now.