### PR TITLE
Remove AS3265 (XS4ALL)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -14,11 +14,6 @@ AS34307:
     import: AS-NL-IX-RS
     export: "AS8283:AS-COLOCLUE"
 
-AS3265:
-    description: XS4ALL
-    import: AS-ACCESSFORALL
-    export: "AS8283:AS-COLOCLUE"
-
 AS12713:
     description: OTEGLOBE
     import: AS-OTEGLOBE


### PR DESCRIPTION
A sad day for the internet in The Netherlands, when XS4ALL leaves the AMS-IX. But nevertheless it is a fact, thus I'm removing the sessions.