### PR TITLE
Remove ChinaCache (AS63541).

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -686,11 +686,6 @@ AS56662:
     import: AS-EUTPNET
     export: AS8283:AS-COLOCLUE
 
-AS63541:
-    description: Chinacache
-    import: AS63541
-    export: AS8283:AS-COLOCLUE
-
 AS44901 :
     description: Belcloud
     import: as-belcloud


### PR DESCRIPTION
This peer gets removed because we don't have any IXPs in common
anymore