### PR TITLE
Add AS8560 (IONOS SE)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -972,3 +972,8 @@ AS23764:
     description: China Telecom
     import: AS-CTGNET
     export: AS8283:AS-COLOCLUE
+
+AS8560:
+    description: IONOS SE
+    import: AS-IONOS
+    export: AS8283:AS-COLOCLUE


### PR DESCRIPTION
Strato has moved everything behind AS8560 and they want to set up a peering connection from AS8560 towards us, so I'm adding that ASN now.