### PR TITLE
Enable AS49627 on NL-ix again

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -801,8 +801,6 @@ AS49627:
     description: Speakup
     import: AS49627
     export: AS8283:AS-COLOCLUE
-    not_on:
-      - nlix
 
 AS37100:
     description: Seacom


### PR DESCRIPTION
The maintenance performed by SpeakUp (AS49627) on their NL-ix connection has been completed. The sessions can be enabled again. Today 1 session will restore, the other one will become established next week