### PR TITLE
Do not peer with AS8298 on the locix

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -896,6 +896,7 @@ AS8298:
       - franceix
       - swissix
       - nlix
+      - locix
 
 AS6695:
     description: DE-CIX Frankfurt Route Servers


### PR DESCRIPTION
We are not a fan of scenic routing, thus there will be no peering session with IPng via LocIX The Netherlands