### PR TITLE
Rename AS29396

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -133,7 +133,7 @@ AS12414:
     export: "AS8283:AS-COLOCLUE"
 
 AS29396:
-    description: UNET
+    description: Eurofiber
     import: AS-UNET
     export: "AS8283:AS-COLOCLUE"
 


### PR DESCRIPTION
AS29396 is known nowadays by the name Eurofiber, so updating that in our config.