### PR TITLE
Increase prefix limit for AS1299

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -471,8 +471,8 @@ AS1299:
     description: TeliaSonera International Carrier
     import: AS-TELIANET AS-TELIANET-V6
     export: "AS8283:AS-COLOCLUE"
-    ipv4_limit: 550000
-    ipv6_limit: 90000
+    ipv4_limit: 605000
+    ipv6_limit: 110000
     ignore_peeringdb: True
     private_peerings:
         - 62.115.144.32


### PR DESCRIPTION
Uping the prefix limit for AS1299, because we are hitting the limit. Should be fine for a while