### PR TITLE
Remove AS56647

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -632,11 +632,6 @@ AS49206:
     import: AS-PEAKFACTORY
     export: "AS8283:AS-COLOCLUE"
 
-AS56647:
-    description: FusionMediaLimited
-    import: AS56647
-    export: "AS8283:AS-COLOCLUE"
-
 AS6762:
     description: Telecom Italia Sparkle
     import: AS-SEABONE


### PR DESCRIPTION
We don't have any IX in common with FusionMediaLimited (AS56647) in common anymore. They didn't clean up their PeeringDB record, so the sessions were still in place. The AMS-IX notified us that we were hitting the arp sponge at their end. The Speed-IX (the only other IX we had in common) IP didn't respond as well, so the decision was made to remove the peering sessions at our end