### PR TITLE
Update test_peers.yaml.yml

### DIFF
--- a/.github/workflows/test_peers.yaml.yml
+++ b/.github/workflows/test_peers.yaml.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-peers-yaml:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 18.04 has been deprecated as testing platform on Github, so upgrading to a newer Ubuntu version.