### PR TITLE
Remove AS211827

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -935,11 +935,6 @@ AS209288:
     import: AS-SOL4XS
     export: AS8283:AS-COLOCLUE
 
-AS211827:
-    description: BnPICT
-    import: AS211827
-    export: AS8283:AS-COLOCLUE
-
 AS204151:
     description: Kviknet.dk ApS
     import: AS204151:AS-PEERING


### PR DESCRIPTION
We don't have any IXes in common anymore with AS211827/BNPICT. He hasn't have any IXes lilsted anymore on his PDB page. Thus removing this peer.