### PR TITLE
Rename AS1103 from "SURFnet" to "SURF", second try

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -534,7 +534,7 @@ AS31500:
     export: "AS8283:AS-COLOCLUE"
 
 AS1103:
-    description: SURFnet
+    description: SURF
     import: AS-SURFNET
     export: "AS8283:AS-COLOCLUE"
 


### PR DESCRIPTION
SURF started rebranding from SURFnet to SURF a few years ago. Updating the name in our system to reflect this rebranding