### PR TITLE
Update CI actions to Node16 versions.

### DIFF
--- a/.github/workflows/test_peers.yaml.yml
+++ b/.github/workflows/test_peers.yaml.yml
@@ -10,14 +10,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install ipaddr requests pyyaml
+
     - name: Test peers.yaml
       run: python ./tests/test_peering_relations.py

--- a/.github/workflows/test_peers.yaml.yml
+++ b/.github/workflows/test_peers.yaml.yml
@@ -3,6 +3,9 @@ name: Test peers.yaml
 
 on:
   push:
+  schedule:
+    # Saturday 04:30 UTC
+    - cron: "30 4 * * 6"
 
 jobs:
   test-peers-yaml:


### PR DESCRIPTION
Current CI runs still use (deprecated) Node12 actions.
Upgrade to more recent versions that use Node16 equivalents.

Note that the failed CI run is due to a peer (AS44654) that ColoClue no longer has an IXP in common with.