### PR TITLE
Remove AS3267

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -92,11 +92,6 @@ AS3856:
     import: AS-PCH
     export: "AS8283:AS-COLOCLUE"
 
-AS3267:
-    description: RUNNet
-    import: AS-RUNNET
-    export: "AS8283:AS-COLOCLUE"
-
 AS30870:
     description: Trans-iX
     import: AS-TRANSIX


### PR DESCRIPTION
AS3267 (RUNNET) has disconnected from the AMS-IX, and this is the only IX we peer with them. So I removed them from peers.yaml.