### PR TITLE
Use RFC7999 BLACKHOLE community on DE-CIX and SwissIX.

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -869,6 +869,12 @@ AS6695:
     description: DE-CIX Frankfurt Route Servers
     import: AS-DECIX AS-DECIX-V6
     export: AS8283:AS-COLOCLUE
+    # https://de-cix.net/en/resources/faqs#Blackholing
+    blackhole_accept: true
+    blackhole_community:
+        - '65535:666'
+        # https://portal.de-cix.net/help-center/article/5355426
+        - 'RT:6695:4200000000'
 
 AS51706:
     description: France-IX Paris Route Servers
@@ -879,6 +885,8 @@ AS42476:
     description: SwissIX Route Servers
     import: AS-SWISSIX-RS
     export: AS8283:AS-COLOCLUE
+    # https://www.swissix.ch/resources/blackholing-guide/
+    blackhole_accept: true
 
 AS57118:
     description: communityrack.org


### PR DESCRIPTION
Companion peering manifest changes to the [KEES PR#53](https://github.com/coloclue/kees/pull/53).

Adds `blackhole_accept` for DE-CIX and Swiss-IX route servers per their (included) documentation.
Note that this also adds `blackhole_community` keys for DE-CIX, even though the KEES code does not (yet) process these; they are for future use.