### PR TITLE
Remove unneeded description at AS112

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -335,7 +335,7 @@ AS47065:
     type: downstream
 
 AS112:
-    description: AS112 Project (Hosted by RIPE NCC at AMS-IX)
+    description: AS112 Project
     import: AS112
     export: "AS8283:AS-COLOCLUE"
 


### PR DESCRIPTION
AS112 is not only hosted by RIPE NCC anymore, so no need to have that specified in the name