### PR TITLE
Remove AS31595

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -287,11 +287,6 @@ AS8359:
     import: AS-MTU
     export: "AS8283:AS-COLOCLUE"
 
-AS31595:
-    description: Redraw Internet
-    import: AS-AWELL
-    export: "AS8283:AS-COLOCLUE"
-
 AS16509:
     description: Amazon
     import: AS-AMAZON


### PR DESCRIPTION
Rocket Fibre (AS31595) has removed all their Public Exchange points from PeeringDB, so we can't make a BGP session with them anymore. Thus removing the config entirely from our Peering list.