### PR TITLE
Remove description at AS112

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -330,7 +330,7 @@ AS47065:
     type: downstream
 
 AS112:
-    description: AS112 Project (Hosted by RIPE NCC at AMS-IX)
+    description: AS112 Project
     import: AS112
     export: "AS8283:AS-COLOCLUE"
 


### PR DESCRIPTION
AS112 is not just hosted at RIPE NCC anymore, it has more people invested in this project now. So, removing the obsolete description.