### PR TITLE
Increase prefix limit AS1299

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -436,8 +436,8 @@ AS1299:
     description: Arelion
     import: AS-TELIANET AS-TELIANET-V6
     export: "AS8283:AS-COLOCLUE"
-    ipv4_limit: 650000
-    ipv6_limit: 120000
+    ipv4_limit: 750000
+    ipv6_limit: 150000
     ignore_peeringdb: true
     private_peerings:
         - 62.115.144.32


### PR DESCRIPTION
From 650,000 to 750,000 for IPv4
from 120,000 to 150,000 for IPv6