### PR TITLE
Increase prefix limit for AS1299 further

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -437,7 +437,7 @@ AS1299:
     import: AS-TELIANET AS-TELIANET-V6
     export: "AS8283:AS-COLOCLUE"
     ipv4_limit: 750000
-    ipv6_limit: 150000
+    ipv6_limit: 175000
     ignore_peeringdb: true
     private_peerings:
         - 62.115.144.32


### PR DESCRIPTION
Increased IPv6 for AS1299 from 150,000 to 175,000, to have a better margin. IPv4 limits have been unchanged