### PR TITLE
Remove AS34779

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -776,11 +776,6 @@ AS201290:
     import: AS-BlackGATE
     export: AS8283:AS-COLOCLUE
 
-AS34779:
-    description: T-2 d.o.o.
-    import: AS-T2-CUST
-    export: AS8283:AS-COLOCLUE
-
 AS394354:
     description: Canadian Internet Registration Authority
     import: AS-394354


### PR DESCRIPTION
Removing T-2 (AS34779), because our peering session is down with them, and they stated that they don't want a direct peering session with us, so no need to keep them in peers.yaml.