### PR TITLE
Remove AS43350

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -551,16 +551,6 @@ AS61955:
         - swissix
         - franceix
 
-AS43350:
-    description: NFOrce Entertainment B.V.
-    import: AS-NFORCE
-    export: "AS8283:AS-COLOCLUE"
-    only_with:
-        - 193.239.116.142
-        - 193.239.116.214
-        - 2001:7f8:13::a504:3350:1
-        - 2001:7f8:13::a504:3350:2
-
 AS48519:
     description: Knipp Medien und Kommunikation GmbH
     import: AS-IRONDNS AS-IRONDNS-v6


### PR DESCRIPTION
NFOrce Entertainment B.V. doesn't want to peer with us directly, and the peering is down anyway, so removing the direct sessions.