### PR TITLE
Remove TransIP (AS20857)

### DIFF
--- a/peers.yaml
+++ b/peers.yaml
@@ -329,11 +329,6 @@ AS8674:
     import: AS-NETNOD
     export: "AS8283:AS-COLOCLUE"
 
-AS20857:
-    description: TransIP
-    import: AS-TRANSIP
-    export: "AS8283:AS-COLOCLUE"
-
 AS6677:
     description: Iceland Telecom Ltd.
     import: AS-ICENET


### PR DESCRIPTION
TransIP is moving behind Team.Blue (AS48185) for BGP. They disabled their AMS-IX sessions today, NL-ix was already down. And we don't have sessions with them on another IXP. We do have fully connected sessions with Team.Blue already, so this TransIP definition is not needed anymore and we will exchange traffic with TransIP via Team.Blue